### PR TITLE
Remove default image from pipeline

### DIFF
--- a/example/item-minimal-data/manifest.json
+++ b/example/item-minimal-data/manifest.json
@@ -63,10 +63,10 @@
   },
   "thumbnail": [
     {
-      "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif/full/250,/0/default.jpg",
+      "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage1.tif/full/250,/0/default.jpg",
       "service": [
         {
-          "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif",
+          "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage1.tif",
           "profile": "http://iiif.io/api/image/2/level2.json",
           "type": "ImageService2"
         }

--- a/example/item-multiple-images/manifest.json
+++ b/example/item-multiple-images/manifest.json
@@ -185,10 +185,10 @@
   ],
   "thumbnail": [
     {
-      "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif/full/250,/0/default.jpg",
+      "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage2.tif/full/250,/0/default.jpg",
       "service": [
         {
-          "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif",
+          "id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage2.tif",
           "profile": "http://iiif.io/api/image/2/level2.json",
           "type": "ImageService2"
         }

--- a/example/item-one-image/manifest.json
+++ b/example/item-one-image/manifest.json
@@ -24,10 +24,10 @@
 	},
 	"viewingDirection": "left-to-right",
 	"thumbnail": [{
-		"id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif/full/250,/0/default.jpg",
+		"id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage1.tif/full/250,/0/default.jpg",
 		"type": "Image",
 		"service": [{
-			"id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fdefault.tif",
+			"id": "https://image-iiif.library.nd.edu:8182/iiif/2/id%2Fimage1.tif",
 			"type": "ImageService2",
 			"profile": "http://iiif.io/api/image/2/level2.json"
 		}]

--- a/finalize/finalizeStep.py
+++ b/finalize/finalizeStep.py
@@ -14,7 +14,6 @@ class finalizeStep():
 
     def run(self):
         if self.success():
-            self.copyDefaultImg()
             self.movePyramids()
             self.moveManifest()
             self.moveSchema()

--- a/manifest-from-input-json/iiifManifest.py
+++ b/manifest-from-input-json/iiifManifest.py
@@ -32,6 +32,9 @@ class iiifManifest(iiifItem):
             manifest['requiredStatement'] = self._convert_label_value(self.manifest_data['requiredStatement'])
         if 'viewingDirection' in self.manifest_data:
             manifest['viewingDirection'] = self.manifest_data['viewingDirection']
+        else:
+            manifest['viewingDirection'] = 'left-to-right'
+
         if 'homepage' in self.manifest_data:
             manifest['homepage'] = self.manifest_data['homepage']
         if 'seeAlso' in self.manifest_data:

--- a/manifest-from-input-json/iiifManifest.py
+++ b/manifest-from-input-json/iiifManifest.py
@@ -56,7 +56,6 @@ class iiifManifest(iiifItem):
             for item in self.manifest_data['items']:
                 if item['file'] == self.manifest_data['thumbnail']:
                     default_page = item.copy()
-                    default_page['file'] = 'default'
 
         return [iiifImage(default_page['file'], self.config).thumbnail()]
 


### PR DESCRIPTION
We are removing this because the original need (primo) to have a commonly named default image is no longer a requirement.  