### PR TITLE
add provider to csv, mets, and manifests

### DIFF
--- a/create_manifest/iiifManifest.py
+++ b/create_manifest/iiifManifest.py
@@ -26,6 +26,10 @@ class iiifManifest(iiifItem):
             }],
             'metadata': []
         }
+
+        if self.creativework_data.get('provider', False):
+            ret['provider'] = self._add_provider(self.creativework_data.get('provider'))
+
         if self.creativework_data.get('license', False):
             ret['requiredStatement'] = self._convert_label_value('Copyright', self.creativework_data['license'])
 
@@ -113,6 +117,87 @@ class iiifManifest(iiifItem):
                 'value': self._lang_wrapper(value)
             }
         return None
+
+    def _add_provider(self, provider):
+        if (provider == 'snite'):
+            return self._snite_proivider()
+        elif (provider == 'archives'):
+            return self._archives_proivider()
+        elif (provider == 'rbsc'):
+            return self._rbsc_proivider()
+
+    def _snite_proivider(self):
+        return {
+            "id": "https://sniteartmuseum.nd.edu/about-us/contact-us/",
+            "type": "Agent",
+            "label": {"en": ["Snite Museum of Art"]},
+            "homepage": [
+                {
+                  "id": "https://sniteartmuseum.nd.edu",
+                  "type": "Text",
+                  "label": {"en": ["Snite Museum of Art"]},
+                  "format": "text/html"
+                }
+            ],
+            "logo": [
+                {
+                  "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+                  "type": "Image",
+                  "format": "image/png",
+                  "height": 100,
+                  "width": 120
+                }
+              ]
+        }
+
+    def _rbsc_proivider(self):
+        return {
+            "id": "https://rarebooks.library.nd.edu/using",
+            "type": "Agent",
+            "label": {"en": ["Rare Books and Special Collections"]},
+            "homepage": [
+                {
+                  "id": "https://rarebooks.library.nd.edu/",
+                  "type": "Text",
+                  "label": {"en": ["Rare Books and Special Collections"]},
+                  "format": "text/html"
+                }
+            ],
+            "logo": [
+                {
+                  "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+                  "type": "Image",
+                  "format": "image/png",
+                  "height": 100,
+                  "width": 120
+                }
+              ]
+        }
+
+    def _archives_proivider(self):
+        return {
+            "id": "http://archives.nd.edu/about/",
+            "type": "Agent",
+            "label": {"en": ["University of Notre Dame Archives"]},
+            "homepage": [
+                {
+                  "id": "http://archives.nd.edu/",
+                  "type": "Text",
+                  "label": {"en": ["University of Notre Dame Archives"]},
+                  "format": "text/html"
+                }
+            ],
+            "logo": [
+                {
+                  "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+                  "type": "Image",
+                  "format": "image/png",
+                  "height": 100,
+                  "width": 120
+                }
+              ]
+        }
+
 
     def _schema_to_metadata_mappings(self):
         return {

--- a/example/item-one-image/manifest.json
+++ b/example/item-one-image/manifest.json
@@ -93,6 +93,36 @@
 			"en": ["license"]
 		}
 	},
+	"provider": {
+    "homepage": [
+      {
+        "format": "text/html",
+        "id": "https://rarebooks.library.nd.edu/",
+        "label": {
+          "en": [
+            "Rare Books and Special Collections"
+          ]
+        },
+        "type": "Text"
+      }
+    ],
+    "id": "https://rarebooks.library.nd.edu/using",
+    "label": {
+      "en": [
+        "Rare Books and Special Collections"
+      ]
+    },
+    "logo": [
+      {
+        "format": "image/png",
+        "height": 100,
+        "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+        "type": "Image",
+        "width": 120
+      }
+    ],
+    "type": "Agent"
+  },	
 	"viewingDirection": "left-to-right",
 	"thumbnail": [{
 		"id": "https://image-iiif.library.nd.edu/iiif/2/identifier%2Fimage1/full/250,/0/default.jpg",

--- a/example/item-one-image/schema.json
+++ b/example/item-one-image/schema.json
@@ -14,7 +14,7 @@
       "copyrightHolder": "copyrightHolder",
       "conditionOfAccess": "conditionOfAccess",
       "sponsor": "sponsor",
-      "provider": "provider",
+      "provider": "rbsc",
       "keywords": "subject",
       "thumbnail": "https://presentation-iiif.library.nd.edu/identifier%2Fimage1.tif",
       "hasPart": [

--- a/process_csv_input/CsvToSchema.py
+++ b/process_csv_input/CsvToSchema.py
@@ -34,6 +34,7 @@ class CsvToSchema():
             else:
                 self.errors.append(key + ' has no value assigned \n')
 
+        main["provider"] = fieldmap["Provider"] if 'Provider' in fieldmap else "rbsc"
         main['thumbnail'] = self.default_image
         main["hasPart"] = []
         for hasPartItem in self.has_part_items:
@@ -57,9 +58,11 @@ class CsvToSchema():
                 del ret_dict["Metadata_label"]
                 del ret_dict["Metadata_value"]
             elif reader.line_num > 2:
-                ret_dict[this_row["Metadata_label"].lower().strip()] = this_row['Metadata_value']
+                key = " ".join(this_row["Metadata_label"].split()).lower()
+                ret_dict[key] = this_row['Metadata_value']
 
         return ret_dict
+
 
     def has_part_items(self):
         ret = []
@@ -132,7 +135,9 @@ class CsvToSchema():
           "provider": "provider",
           "datecreated": "dateCreated",
           "conditionofaccess": "conditionOfAccess",
-          "materialextent": "materialExtent"
+          "materialextent": "materialExtent",
+          "accessnotes": "notes",
+          "datecreated": "dateCreated"
         }
 
     def remomve_file_extension(self, file):

--- a/process_mets_input/MetsToSchema.py
+++ b/process_mets_input/MetsToSchema.py
@@ -46,6 +46,7 @@ class MetsToSchema():
             if xml_value is not None and xml_value.text is not None:
                 main[schema_key] = xml_value.text
 
+        main["provider"] = "snite"
         main['thumbnail'] = self.default_image
         main["hasPart"] = []
         for hasPartItem in self.has_part_items:

--- a/test/debug/result.json
+++ b/test/debug/result.json
@@ -135,6 +135,36 @@
       }
     }
   ],
+  "provider": {
+    "homepage": [
+      {
+        "format": "text/html",
+        "id": "https://rarebooks.library.nd.edu/",
+        "label": {
+          "en": [
+            "Rare Books and Special Collections"
+          ]
+        },
+        "type": "Text"
+      }
+    ],
+    "id": "https://rarebooks.library.nd.edu/using",
+    "label": {
+      "en": [
+        "Rare Books and Special Collections"
+      ]
+    },
+    "logo": [
+      {
+        "format": "image/png",
+        "height": 100,
+        "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+        "type": "Image",
+        "width": 120
+      }
+    ],
+    "type": "Agent"
+  },
   "requiredStatement": {
     "label": {
       "en": [

--- a/test/debug/test.json
+++ b/test/debug/test.json
@@ -135,6 +135,36 @@
       }
     }
   ],
+  "provider": {
+    "homepage": [
+      {
+        "format": "text/html",
+        "id": "https://rarebooks.library.nd.edu/",
+        "label": {
+          "en": [
+            "Rare Books and Special Collections"
+          ]
+        },
+        "type": "Text"
+      }
+    ],
+    "id": "https://rarebooks.library.nd.edu/using",
+    "label": {
+      "en": [
+        "Rare Books and Special Collections"
+      ]
+    },
+    "logo": [
+      {
+        "format": "image/png",
+        "height": 100,
+        "id": "https://sniteartmuseum.nd.edu/stylesheets/images/snite_logo@2x.png",
+        "type": "Image",
+        "width": 120
+      }
+    ],
+    "type": "Agent"
+  },
   "requiredStatement": {
     "label": {
       "en": [

--- a/test/test_mets_to_schema.py
+++ b/test/test_mets_to_schema.py
@@ -2,7 +2,7 @@ import unittest
 import json
 from process_mets_input.MetsToSchema import MetsToSchema
 from test.test_utils import load_data_for_test
-# from test.test_utils import debug_json
+#from test.test_utils import debug_json
 
 
 class TestProcessCsvOutput(unittest.TestCase):
@@ -19,8 +19,9 @@ class TestProcessCsvOutput(unittest.TestCase):
             print("Testing id, {}".format(id))
             data = load_data_for_test(id)
             self.metsSet = MetsToSchema(data['config'], data['descriptive_metadata'], data['structural_metadata'], data['image_data'])
-            # debug_json(data['schema_json'], self.metsSet.get_json())
 
+            data['schema_json']['@graph'][0]['provider'] = 'snite'
+            # debug_json(data['schema_json'], self.metsSet.get_json())
             schema_json = "".join(json.dumps(data['schema_json'], sort_keys=True).split())
             result_json = "".join(json.dumps(self.metsSet.get_json(), sort_keys=True).split())
 


### PR DESCRIPTION
I added a process for setting the provider information in manifests.

to the csv file (it can be added as a csv key)
to mets at the moment it is always snite. 
and to the manifest creation itself.  

