### PR TITLE
added __init__.py to fix problem with lambda not finding sentry_sdk

### DIFF
--- a/aleph_export/__init__.py
+++ b/aleph_export/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+where_i_am = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(where_i_am)
+sys.path.append(where_i_am + "/dependencies/")
+sys.path.append(where_i_am + "/dependencies/pipelineutilities/")

--- a/aleph_export/local_install.sh
+++ b/aleph_export/local_install.sh
@@ -4,7 +4,7 @@
 magenta=`tput setaf 5`
 reset=`tput sgr0`
 
-echo "\n\n ${magenta}----- find_objects LOCAL_INSTALL.SH -----${reset}"
+echo "\n\n ${magenta}----- aleph_export LOCAL_INSTALL.SH -----${reset}"
 
 rm -rf ./dependencies
 

--- a/harvest_eads/__init__.py
+++ b/harvest_eads/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+where_i_am = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(where_i_am)
+sys.path.append(where_i_am + "/dependencies/")
+sys.path.append(where_i_am + "/dependencies/pipelineutilities/")

--- a/harvest_eads/local_install.sh
+++ b/harvest_eads/local_install.sh
@@ -4,7 +4,7 @@
 magenta=`tput setaf 5`
 reset=`tput sgr0`
 
-echo "\n\n ${magenta}----- find_objects LOCAL_INSTALL.SH -----${reset}"
+echo "\n\n ${magenta}----- harvest_eads LOCAL_INSTALL.SH -----${reset}"
 
 rm -rf ./dependencies
 

--- a/museum_export/__init__.py
+++ b/museum_export/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+where_i_am = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(where_i_am)
+sys.path.append(where_i_am + "/dependencies/")
+sys.path.append(where_i_am + "/dependencies/pipelineutilities/")

--- a/museum_export/handler.py
+++ b/museum_export/handler.py
@@ -4,11 +4,11 @@
 import os
 import json
 from pathlib import Path
+from process_web_kiosk_json_metadata import processWebKioskJsonMetadata
 from dependencies.pipelineutilities.pipeline_config import get_pipeline_config, load_config_ssm
+from dependencies.pipelineutilities.google_utilities import establish_connection_with_google_api
 import dependencies.sentry_sdk as sentry_sdk
 from dependencies.sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-from process_web_kiosk_json_metadata import processWebKioskJsonMetadata
-from dependencies.pipelineutilities.google_utilities import establish_connection_with_google_api
 
 
 if 'SENTRY_DSN' in os.environ:

--- a/museum_export/local_install.sh
+++ b/museum_export/local_install.sh
@@ -4,7 +4,7 @@
 magenta=`tput setaf 5`
 reset=`tput sgr0`
 
-echo "\n\n ${magenta}----- find_objects LOCAL_INSTALL.SH -----${reset}"
+echo "\n\n ${magenta}----- museum_export LOCAL_INSTALL.SH -----${reset}"
 
 rm -rf ./dependencies
 


### PR DESCRIPTION
In local testing, if I was in the folder for the lambda and ran it, everything worked fine.  If I was one level up, and ran it fully qualified, I got errors.

Once I added the __init__.py to fix paths, the errors resolved.

Hopefully, this will fix the problem with the lambda not finding sentry_sdk.

(I had removed the additions to the path from my code, thinking that fully qualifying paths would work instead.)
