### PR TITLE
fix to try and copy copyrighted images up to the image server.

### DIFF
--- a/pipelineutilities/pipelineutilities/search_files.py
+++ b/pipelineutilities/pipelineutilities/search_files.py
@@ -217,16 +217,14 @@ def output_as_file():
 def test():
     from pipeline_config import setup_pipeline_config
     event = {"local": True}
-    event['local-path'] = "/Users/jhartzle/Workspace/mellon-manifest-pipeline/process_manifest/../example/"
-    event['local-path'] = "../../example/"
 
     config = setup_pipeline_config(event)
-
+    # change to the prod bucket
     config['rbsc-image-bucket'] = "libnd-smb-rbsc"
-    # data = crawl_available_files(config)
-    id = id_from_url("https://rarebooks.nd.edu/digital/civil_war/diaries_journals/images/arthur/8001-01.150.jpg")
+    data = crawl_available_files(config)
+    id = id_from_url("https://rarebooks.library.nd.edu/digital/MARBLE-images/BOO_002468275/BOO_002468275_000001.tif")
     print(id)
-    # print(data[id])
+    print(data[id])
     # print(id)
 
     return

--- a/pyramid_generator/gdrive_processor.py
+++ b/pyramid_generator/gdrive_processor.py
@@ -24,7 +24,7 @@ class GoogleImageProcessor(ImageProcessor):
             self.max_img_width = 843.0
 
     def process(self) -> dict:
-        if self._previously_processed() and not self.copyrighted:
+        if self._previously_processed():
             file_info = self.prior_results.get(self.id).get(self.filename)
             height = file_info.get('height', 2000)
             width = file_info.get('width', 2000)

--- a/pyramid_generator/gdrive_processor.py
+++ b/pyramid_generator/gdrive_processor.py
@@ -18,7 +18,7 @@ class GoogleImageProcessor(ImageProcessor):
         self.img_write_base = config.get('img_write_base')
         self.source_md5sum = img_data.get('md5Checksum', None)
         # if copyrighted work scale height/width directed by aamd.org
-        if self._is_copyrighted(img_data.get('usage')):
+        if self._is_copyrighted(img_data.collection().get('copyrightStatus')):
             self.copyrighted = True
             self.max_img_height = 560.0
             self.max_img_width = 843.0

--- a/pyramid_generator/gdrive_processor.py
+++ b/pyramid_generator/gdrive_processor.py
@@ -19,11 +19,12 @@ class GoogleImageProcessor(ImageProcessor):
         self.source_md5sum = img_data.get('md5Checksum', None)
         # if copyrighted work scale height/width directed by aamd.org
         if self._is_copyrighted(img_data.get('usage')):
+            self.copyrighted = True
             self.max_img_height = 560.0
             self.max_img_width = 843.0
 
     def process(self) -> dict:
-        if self._previously_processed():
+        if self._previously_processed() and not self.copyrighted:
             file_info = self.prior_results.get(self.id).get(self.filename)
             height = file_info.get('height', 2000)
             width = file_info.get('width', 2000)

--- a/pyramid_generator/image_processor.py
+++ b/pyramid_generator/image_processor.py
@@ -55,6 +55,8 @@ class ImageProcessor(ABC):
             img_data = f"{self.img_write_base}/{self.id}/image_data.json"
             self._set_prior_run_data(self.bucket, img_data, self.id)
         prior_md5sum = self.prior_results.get(self.id).get(self.filename, {}).get('md5sum', 'nomatch')
+        if self.copyrighted:
+            return False
         if self.source_md5sum == prior_md5sum:
             return True
         return False

--- a/pyramid_generator/image_processor.py
+++ b/pyramid_generator/image_processor.py
@@ -28,6 +28,7 @@ class ImageProcessor(ABC):
         self.image_result = {}
         self.max_img_height = 8500.0
         self.max_img_width = 8500.0
+        self.copyrighted = False
 
     @abstractmethod
     def process(self) -> dict:
@@ -105,5 +106,6 @@ class ImageProcessor(ABC):
         self.source_md5sum = img_data.get('md5Checksum', None)
         # if copyrighted work scale height/width directed by aamd.org
         if self._is_copyrighted(img_data.get('copyrightStatus')):
+            self.copyrighted = True
             self.max_img_height = 560.0
             self.max_img_width = 843.0

--- a/pyramid_generator/pyramid.py
+++ b/pyramid_generator/pyramid.py
@@ -23,11 +23,8 @@ class ImageRunner():
 
     def process_images(self) -> None:
         for id in self.ids:
-            print(id)
-            print(load_csv_data(id, self.csv_config))
             id_results = {}
             for file in load_csv_data(id, self.csv_config).files():
-                print(file)
                 if not self.processor:
                     processor_info = self._get_processor_info(file.get('filePath'))
                     src = processor_info.get('type')

--- a/pyramid_generator/test.py
+++ b/pyramid_generator/test.py
@@ -7,8 +7,10 @@ sys.path.append(where_i_am + "/../pipelineutilities/pipelineutilities")
 from pyramid import ImageRunner
 from pipeline_config import load_pipeline_config
 
-
-event = json.loads( "{\"config-file\": \"2020-04-23-13:03:42.346710.json\", \"process-bucket\": \"marble-manifest-prod-processbucket-kskqchthxshg\", \"errors\": [], \"local\": false}")
-config = load_pipeline_config(event)
-runner = ImageRunner(config)
-runner.process_images()
+try:
+    event = json.loads("{\"config-file\": \"2020-04-28-12:43:07.205855.json\", \"process-bucket\": \"marble-manifest-prod-processbucket-kskqchthxshg\", \"errors\": [], \"local\": false}")
+    config = load_pipeline_config(event)
+    runner = ImageRunner(config)
+    runner.process_images()
+except Exception as e:
+    print(e)


### PR DESCRIPTION
The problem was 2 fold.  
  1. if a copyrighted image was originally processed as a full size image the checksum test would pass and say the image was already on the server.
  2. we were testing the copyright status on the image not on the item.  so we have to test the status on the root object. 

Fix.

The basic idea is set a field in the image processor if it is copyrighted. 

Later when we are deciding if the image has already been processed copyrighted images are set to always process. 

Fix when were we test if the image is copyrighted.  


