### PR TITLE
deploy the new nd.json

### DIFF
--- a/pipelineutilities/pipelineutilities/s3_helpers.py
+++ b/pipelineutilities/pipelineutilities/s3_helpers.py
@@ -78,7 +78,7 @@ class InprocessBucket():
     def write_nd_json(self):
         to_path = self.basepath + "/metadata/nd/index.json"
         from_path = "json/" + self.id + ".json"
-        
+
         s3_copy_data(self.process_bucket, to_path, self.process_bucket, from_path)
 
 

--- a/pipelineutilities/pipelineutilities/s3_helpers.py
+++ b/pipelineutilities/pipelineutilities/s3_helpers.py
@@ -75,9 +75,11 @@ class InprocessBucket():
         path = self.basepath + "/" + id + ".csv"
         write_s3_file(self.process_bucket, path, csv)
 
-    def write_nd_json(self, data):
-        path = self.basepath + "/metadata/nd/index.json"
-        write_s3_json(self.process_bucket, path, data)
+    def write_nd_json(self):
+        to_path = self.basepath + "/metadata/nd/index.json"
+        from_path = "json/" + self.id + ".json"
+        
+        s3_copy_data(self.process_bucket, to_path, self.process_bucket, from_path)
 
 
 def read_s3_file_content(s3Bucket, s3Path):

--- a/process_manifest/handler.py
+++ b/process_manifest/handler.py
@@ -40,6 +40,9 @@ def run(event, context):
         if id not in config['processed_ids']:
             inprocess_bucket = InprocessBucket(id, config)
 
+            # move the nd json into the process bucket.
+            inprocess_bucket.write_nd_json()
+
             parent = load_csv_data(id, config)
 
             mapping = MetadataMappings(parent)
@@ -51,9 +54,6 @@ def run(event, context):
                 inprocess_bucket.write_sub_manifest(item)
 
             inprocess_bucket.write_manifest(manifest)
-
-            nd = ndJson(id, config, parent)
-            inprocess_bucket.write_nd_json(nd.to_hash())
 
             schema = ToSchema(id, config, parent)
             inprocess_bucket.write_schema_json(schema.get_json())


### PR DESCRIPTION
Start using the nd.json that is being generated by the metadata extraction process.  

Changed to copy the file that steve created to the process space so it can get deployed by the manifest process.   