### PR TITLE
Set files_api timeout to 890 seconds

### DIFF
--- a/object_files_api/files_api.py
+++ b/object_files_api/files_api.py
@@ -14,7 +14,7 @@ class FilesApi():
         self.event['local'] = self.event.get('local', False)
         self.config = config
         self.local_folder = os.path.dirname(os.path.realpath(__file__)) + "/"
-        self.time_to_break = datetime.now() + timedelta(seconds=899)
+        self.time_to_break = datetime.now() + timedelta(seconds=890)
         if self.config.get('test', False):
             self.directory = os.path.join(os.path.dirname(__file__), 'test')
         else:

--- a/object_files_api/handler.py
+++ b/object_files_api/handler.py
@@ -2,7 +2,6 @@
 
 import _set_path  # noqa
 import os
-from api_helpers import success
 from pipeline_config import setup_pipeline_config
 import sentry_sdk as sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
@@ -19,7 +18,8 @@ def run(event, context):
     config = setup_pipeline_config(event)
     files_api_class = FilesApi(event, config)
     directories = files_api_class.save_files_details()
-    return success(directories)
+    event['objectFilesApiDirectoriesCount'] = len(directories)
+    return event
 
 
 # aws-vault exec libnd-wse-admin --session-ttl=1h --assume-role-ttl=1h --


### PR DESCRIPTION
* toyed with idea of using boto3 to write instead of calling s3_helpers, but existing check of file before re-writing actually saves time on subsequent runs.
* return count of directories processed.