### PR TITLE
Modified metadata extracted from Aleph

### DIFF
--- a/aleph_export/marc_to_json_translation_control_file.json
+++ b/aleph_export/marc_to_json_translation_control_file.json
@@ -68,12 +68,12 @@
 				"note": "added 5/15/20 sm"
 			},
 			{ "label": "collections",
-				"fields": ["710"],
+				"fields": ["791"],
 				"selection": "range",
 				"subfields": ["a", "b", "c", "d", "e", "q"],
 				"specialSubfields": ["d"],
 				"format": "array",
-				"note": "added 7/20/20 sm"
+				"note": ["added 710 7/20/20 sm", "changed 710 to 791 8/26020 sm"]
 			},
 			{ "label": "createdDate",
 				"fields": ["264", "260"],
@@ -92,9 +92,11 @@
 				"selection": "range",
 				"skipFields": ["655", "690"],
 				"subfields": ["a", "b", "c", "d", "e", "f", "g", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"],
+				"subfieldSeparator": " -- ",
 				"specialSubfields": ["0"],
 				"extraProcessing": "format_subjects",
-				"format": "array"
+				"format": "array",
+				"note": "these subfields are defined here: https://www.loc.gov/marc/bibliographic/bd650.html and https://www.loc.gov/marc/bibliographic/bd6xx.html"
 			},
 			{ "label": "copyrightStatus",
 				"fields": ["542"],

--- a/aleph_export/test/sample_standard.json
+++ b/aleph_export/test/sample_standard.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": 1,
-  "fileCreatedDate": "2020-07-23",
+  "fileCreatedDate": "2020-08-26",
   "sourceSystem": "Aleph",
   "repository": "RARE",
   "sequence": 1,
@@ -46,24 +46,22 @@
       "display": "O'Neill, Francis, 1848-1936 donor."
     }
   ],
-  "collections": [
-    "Capt. Francis O'Neill Collection of Irish Studies (University of Notre Dame. Library)"
-  ],
+  "collections": [],
   "createdDate": "[1796?]",
   "workType": "Notated music",
   "subjects": [
     {
-      "term": "Folk songs Ireland Instrumental settings."
+      "term": "Folk songs -- Ireland -- Instrumental settings."
     },
     {
-      "term": "Songs, Irish Ireland Instrumental settings."
+      "term": "Songs, Irish -- Ireland -- Instrumental settings."
     },
     {
       "term": "Piano music, Arranged.",
       "uri": "http://id.loc.gov/authorities/subjects/sh85101791"
     },
     {
-      "term": "Folk music Ireland.",
+      "term": "Folk music -- Ireland.",
       "uri": "http://id.loc.gov/authorities/subjects/sh98002834"
     }
   ],
@@ -90,7 +88,7 @@
       "sourceSystem": "Aleph",
       "repository": "RARE",
       "apiVersion": 1,
-      "fileCreatedDate": "2020-07-23",
+      "fileCreatedDate": "2020-08-26",
       "level": "file",
       "sequence": 1,
       "thumbnail": true,

--- a/aleph_export/test_transform_marc_json.py
+++ b/aleph_export/test_transform_marc_json.py
@@ -36,11 +36,11 @@ class Test(unittest.TestCase):
         }
         subfields_needed_list = ["a", "b", "c", "e", "q"]
         sepcial_subfields_list = []
-        actual_results = self.transform_marc_json_class._get_required_subfields(subfields_dict, subfields_needed_list, sepcial_subfields_list)
+        actual_results = self.transform_marc_json_class._get_required_subfields(subfields_dict, subfields_needed_list, sepcial_subfields_list, " ")
         expected_results = "Crocker, Richard L., author, performer."
         self.assertTrue(actual_results == expected_results)
         sepcial_subfields_list = ["d"]
-        actual_results = self.transform_marc_json_class._get_required_subfields(subfields_dict, subfields_needed_list, sepcial_subfields_list)
+        actual_results = self.transform_marc_json_class._get_required_subfields(subfields_dict, subfields_needed_list, sepcial_subfields_list, " ")
         expected_results = "Crocker, Richard L., author, performer.^^^1910-1963,"
         self.assertTrue(actual_results == expected_results)
 

--- a/aleph_export/transform_marc_json.py
+++ b/aleph_export/transform_marc_json.py
@@ -64,6 +64,7 @@ class TransformMarcJson():
         """ More detailed logic to extract value from json representation of marc record,
             as defined by marc_to_json_translation_control_file.json """
         subfields_needed = json_field_definition.get("subfields", "")
+        subfield_separator = json_field_definition.get("subfieldSeparator", " ")
         positions = json_field_definition.get("positions", "")
         format = json_field_definition.get("format", "")
         extra_processing = json_field_definition.get("extraProcessing", "")
@@ -73,7 +74,7 @@ class TransformMarcJson():
             for key, value in field.items():
                 if self._process_this_field(json_field_definition, key, value):
                     if 'subfields' in value:
-                        value_found = self._get_required_subfields(value, subfields_needed, special_subfields)
+                        value_found = self._get_required_subfields(value, subfields_needed, special_subfields, subfield_separator)
                     elif positions != "":
                         value_found = self._get_required_positions(value, positions)
                     else:
@@ -141,7 +142,7 @@ class TransformMarcJson():
                 results += value[position]
         return results
 
-    def _get_required_subfields(self, subfields: dict, subfields_needed: list, special_subfields: list) -> dict:
+    def _get_required_subfields(self, subfields: dict, subfields_needed: list, special_subfields: list, subfield_separator: str) -> dict:
         """ Append values from subfields we're interested in """
         results = ""
         for subfield in subfields['subfields']:
@@ -150,9 +151,9 @@ class TransformMarcJson():
                     if results == "":
                         results = value
                     else:
-                        results += " " + value
+                        results += subfield_separator + value
         if special_subfields:  # separate special subfields, at the end of the string
-            subfield_results = self._get_required_subfields(subfields, special_subfields, [])
+            subfield_results = self._get_required_subfields(subfields, special_subfields, [], subfield_separator)
             if subfield_results:
                 results += "^^^" + subfield_results
         return results

--- a/archivesspace_export/handler.py
+++ b/archivesspace_export/handler.py
@@ -90,6 +90,7 @@ def test(identifier=""):
         event = {}
         event["local"] = False
         event["ids"] = [
+            # "https://archivesspace.library.nd.edu/repositories/2/resources/1652",  # Collegiate Jazz Festival
             # "https://archivesspace.library.nd.edu/repositories/3/resources/1631",
             # "https://archivesspace.library.nd.edu/repositories/3/resources/1644",  # Irish Broadsides
         ]

--- a/archivesspace_export/xml_to_json_translation_control_file.json
+++ b/archivesspace_export/xml_to_json_translation_control_file.json
@@ -277,6 +277,18 @@
 				"seedNodes": [{"collectionId": "collectionId"}, {"passedParentId": "passedParentId"}, {"sourceSystem": "sourceSystem"}, {"repository": "repository"},
 					{"apiVersion": "apiVersion"}, {"fileCreatedDate": "fileCreatedDate"}, {"passedParentId": "id"}],
 				"checkForInconsistencies": ["fileId"]
+			},
+			{
+				"label": "items",
+				"otherNodes": "dao",
+				"xpath": "./dao",
+				"optional": true,
+				"collapseTree": false,
+				"seedNodes": [{"collectionId": "collectionId"}, {"passedParentId": "passedParentId"}, {"sourceSystem": "sourceSystem"}, {"repository": "repository"},
+					{"apiVersion": "apiVersion"},	{"fileCreatedDate": "fileCreatedDate"},	{"passedParentId": "id"}],
+				"checkForInconsistencies": [
+					"fileId"
+				]
 			}
 		]
 	},
@@ -317,6 +329,58 @@
 				"label": "id",
 				"externalProcess": "file_name_from_filePath",
 				"passLabels": [{"filename": "filePath"}]
+			}
+		]
+	},
+	"dao": {
+		"FieldsToExtract": [
+			{
+				"label": "level",
+				"constant": "file",
+				"format": "text"
+			},
+			{
+				"label": "thumbnail",
+				"constant": true,
+				"format": "text"
+			},
+			{
+				"label": "description",
+				"xpath": "./daodesc/p",
+				"optional": true,
+				"format": "text"
+			},
+			{
+				"label": "filePath",
+				"xpath": ".",
+				"optional": true,
+				"returnAttributeName": "href",
+				"removeDuplicates": true,
+				"excludePattern": [
+					".shtml"
+				],
+				"format": "text"
+			},
+			{
+				"label": "parentId",
+				"fromLabels": [
+					"passedParentId"
+				],
+				"format": "text"
+			},
+			{
+				"removeNodes": [
+					"passedParentId"
+				]
+			},
+			{
+				"label": "id",
+				"externalProcess": "file_name_from_filePath",
+				"passLabels": [
+					{
+						"filename": "filePath"
+					}
+				]
 			}
 		]
 	},


### PR DESCRIPTION
* Changed harvest of collections from 710 to 791 fields to include only collections, and not collaborators.
* Added dash separators between subject subfields to help subsequent processes distinguish them.