### PR TITLE
Fix subject terms bug

### DIFF
--- a/pipelineutilities/pipelineutilities/expand_getty_aat_terms.py
+++ b/pipelineutilities/pipelineutilities/expand_getty_aat_terms.py
@@ -83,12 +83,14 @@ def _get_each_broader_term(xml: ElementTree, xpath: str) -> list:
 
 def _parse_parent_string_into_broader_terms(parent_string: str) -> list:
     """ Given the string of the parent hierarchy, return list of broader terms """
+    break_on_terms = ["styles, periods, and cultures by region"]
     broader_terms = []
-    parent_list = parent_string.split(",")
+    parent_list = parent_string.split("],")
     for i, list_item in enumerate(parent_list):
+        list_item += ']'  # add back in bracket we removed as part of the split        term = _get_term_from_string(list_item)
         term = _get_term_from_string(list_item)
         uri = _get_uri_from_string(list_item)
-        if 'hierarchy name' in term:
+        if 'hierarchy name' in term or term in break_on_terms:
             break
         broader_term = {}
         broader_term['authority'] = 'AAT'
@@ -96,8 +98,8 @@ def _parse_parent_string_into_broader_terms(parent_string: str) -> list:
         if uri:
             broader_term['uri'] = uri
         if i < len(parent_list) - 1:
-            parent_term = _get_term_from_string(parent_list[i + 1])
-            if 'hierarchy name' not in parent_term:
+            parent_term = _get_term_from_string(parent_list[i + 1] + ']')
+            if 'hierarchy name' not in parent_term and parent_term not in break_on_terms:
                 broader_term['parentTerm'] = parent_term
         broader_terms.append(broader_term)
     return broader_terms
@@ -168,8 +170,8 @@ def test():
     """ test exection """
     seed_json = {
         "authority": "AAT",
-        "term": "crowns",
-        "uri": "http://vocab.getty.edu/aat/300046020",
+        "term": "Benin",
+        "uri": "http://vocab.getty.edu/aat/300015777",
     }
     resulting_json = expand_aat_terms(seed_json)
     print("Final output = ", resulting_json)

--- a/pipelineutilities/test/test_expand_getty_aat_terms.py
+++ b/pipelineutilities/test/test_expand_getty_aat_terms.py
@@ -55,6 +55,17 @@ class Test(unittest.TestCase):
         ]
         self.assertEqual(actual_results, expected_results)
 
+    def test_05_5_parse_parent_string_into_broader_terms(self):
+        """ test_05_5_parse_parent_string_into_broader_terms"""
+        parent_string = "North American [300134121], American regions [300107946], Americas, The [300016617], styles, periods, and cultures by region [300111079], Styles and Periods (hierarchy name) [300015646], Styles and Periods Facet [300264088]"  # noqa: E501
+        actual_results = _parse_parent_string_into_broader_terms(parent_string)
+        expected_results = [
+            {"authority": "AAT", "term": "North American", "uri": "http://vocab.getty.edu/aat/300134121", "parentTerm": "American regions"},
+            {"authority": "AAT", "term": "American regions", "uri": "http://vocab.getty.edu/aat/300107946", "parentTerm": "Americas, The"},
+            {"authority": "AAT", "term": "Americas, The", "uri": "http://vocab.getty.edu/aat/300016617"}
+        ]
+        self.assertEqual(actual_results, expected_results)
+
     @patch('pipelineutilities.expand_getty_aat_terms._get_xml_string_given_url')
     def test_06_get_xml_string_given_url(self, mock_get_xml_string_given_url):
         """ text_06 basically test the whole process given a mocked xml """


### PR DESCRIPTION
* Instead of splitting AAT terms by comma, we are now using "],", and then adding back in the "]".
* We are also stopping the harvent when we hit the term "styles, periods, and cultures by region" per Abby.

This fixes the two examples Abby provided here:  https://jira.library.nd.edu/secure/RapidBoard.jspa?rapidView=113&view=detail&selectedIssue=MARBLE-1182.