### PR TITLE
fix for replace of objects from snite

### DIFF
--- a/pipelineutilities/pipelineutilities/s3_helpers.py
+++ b/pipelineutilities/pipelineutilities/s3_helpers.py
@@ -5,6 +5,7 @@ import json
 from os.path import basename
 from os import remove
 import hashlib
+import re
 
 
 def get_matching_s3_objects(bucket: str, prefix: str = "", suffix: str = "") -> list:
@@ -56,8 +57,7 @@ class InprocessBucket():
     def write_sub_manifest(self, data):
         path = data.get('id')
         path = path.replace(self.manifest_url + "/", '')
-        path = path.replace(self.id, 'metadata')
-        path = path + "/index.json"
+        path = re.sub(r'^' + self.id + '[/]', 'metadata/', path)        path = path + "/index.json"
         path = self.basepath + "/" + path
         # .replace(self.id, 'metadata') + "/index.json"
         write_s3_json(self.process_bucket, path, data)

--- a/pipelineutilities/pipelineutilities/s3_helpers.py
+++ b/pipelineutilities/pipelineutilities/s3_helpers.py
@@ -57,7 +57,8 @@ class InprocessBucket():
     def write_sub_manifest(self, data):
         path = data.get('id')
         path = path.replace(self.manifest_url + "/", '')
-        path = re.sub(r'^' + self.id + '[/]', 'metadata/', path)        path = path + "/index.json"
+        path = re.sub(r'^' + self.id + '[/]', 'metadata/', path)
+        path = path + "/index.json"
         path = self.basepath + "/" + path
         # .replace(self.id, 'metadata') + "/index.json"
         write_s3_json(self.process_bucket, path, data)

--- a/process_manifest/handler.py
+++ b/process_manifest/handler.py
@@ -78,7 +78,6 @@ def sub_manifests(manifest):
     for item in manifest.get('items', []):
         if item.get('type').lower() == 'manifest':
             ret.append(item)
-
         ret = ret + sub_manifests(item)
 
     return ret
@@ -89,11 +88,14 @@ def test():
     # import pprint
     # pp = pprint.PrettyPrinter(indent=4)
     event = {
-        'ssm_key_base': '/all/marble-manifest-prod',
-        'config-file': '2020-06-22-13:55:36.698390.json',
-        'process-bucket': 'marble-manifest-prod-processbucket-kskqchthxshg',
+        'ssm_key_base': '/all/sm-prod-manifest',
+        'config-file': '2020-10-24-08:00:38.786177.json',
+        'seconds-to-allow-for-processing': 60,
+        'process-bucket': 'sm-prod-manifest-processbuckete5460fc2-dgivk9llzj2h',
+        'process_manifest_run_number': 1,
+        'processed_ids': [],
         'ids': [
-            'BPP1001_EAD'
+            '2012.045.001'
         ],
         'errors': []
     }


### PR DESCRIPTION
The issue was only with snite objects that have children and we never saw it before because there were not any. 

the file naming was double replacing the id.  
regular expression to ensure it is more targeted.  