### PR TITLE
Remediate truncated ArchivesSpace xml fields

### DIFF
--- a/archivesspace_export/create_json_from_xml.py
+++ b/archivesspace_export/create_json_from_xml.py
@@ -115,7 +115,20 @@ def get_xml_node_value(item: ElementTree, return_attribute_name: str, exclude_pa
     if return_attribute_name in item.attrib:
         value_found = item.attrib[return_attribute_name]
     else:
-        value_found = item.text
+        safe_to_try_tostring = False
+        for child in item:
+            if child.tag == 'extref':
+                safe_to_try_tostring = True
+            else:
+                safe_to_try_tostring = False
+                break
+        if safe_to_try_tostring:
+            root_tag = item.tag
+            value_found = ElementTree.tostring(item, encoding='unicode')
+            value_found = value_found.replace('<' + root_tag + '>', '').replace('</' + root_tag + '>', '')
+            value_found = value_found.replace('<extref', '<a').replace('</extref>', '</a>')
+        else:
+            value_found = item.text
     value_found = exclude_if_pattern_matches(exclude_pattern, value_found)
     value_found = strip_unwanted_whitespace(value_found)
     return value_found

--- a/archivesspace_export/handler.py
+++ b/archivesspace_export/handler.py
@@ -100,7 +100,7 @@ def test():
         event["local"] = False
         event['seconds-to-allow-for-processing'] = 9000
         event["ids"] = [
-            # "https://archivesspace.library.nd.edu/repositories/2/resources/1652",  # Collegiate Jazz Festival
+            "https://archivesspace.library.nd.edu/repositories/2/resources/1652",  # Collegiate Jazz Festival
             # "https://archivesspace.library.nd.edu/repositories/3/resources/1631",    # Inquisitions (MSHLAT0090_EAD)
             # "https://archivesspace.library.nd.edu/repositories/3/resources/1447",
             # "https://archivesspace.library.nd.edu/repositories/3/resources/1567",

--- a/archivesspace_export/test_create_json_from_xml.py
+++ b/archivesspace_export/test_create_json_from_xml.py
@@ -4,7 +4,7 @@ import _set_path  # noqa
 import os
 import json
 import unittest
-from create_json_from_xml import createJsonFromXml
+from create_json_from_xml import createJsonFromXml, get_xml_node_value
 import xml.etree.ElementTree as ET
 
 
@@ -78,6 +78,14 @@ class Test(unittest.TestCase):
             expected_results = {'id': 'aspace_8f5be6708c2e98e57a60eddf20e36679', 'title': 'Theophilus Parsons, Journal, vol. 1', 'createdDate': 'January 1819-December 1820', 'uniqueIdentifier': 'MSN/EA 8011-1-B', 'items': [{'level': 'file', 'thumbnail': True, 'description': 'Theophilus Parsons, Journal, vol. 1', 'filePath': 'https://rarebooks.library.nd.edu/digital/bookreader/MSN-EA_8011-1-B/images/MSN-EA_8011-01-B-000a.jpg', 'parentId': 'aspace_8f5be6708c2e98e57a60eddf20e36679', 'id': 'MSN-EA_8011-01-B-000a.jpg'}], 'level': 'manifest'}  # noqa: E501
             self.assertEqual(expected_results, actual_results)
             break
+
+    def test_4_test_get_xml_node_value(self):
+        """ test 4_test_get_xml_node_value """
+        xml = '<p>Access to university records in any format(paper, digital, photographic, or audiovisual) is governed by state and federal laws, University of Notre Dame policy, and the <extref href = "http://archives.nd.edu/about/accesspolicy.pdf" >University of Notre Dame Archives Access Guidelines </extref>and is subject to review under the supervision of the Head of the University Archives.</p>'  # noqa: E501
+        xml_record = xml_record = ET.fromstring(xml)
+        actual_results = get_xml_node_value(xml_record, None, [])
+        expected_results = 'Access to university records in any format(paper, digital, photographic, or audiovisual) is governed by state and federal laws, University of Notre Dame policy, and the <a href="http://archives.nd.edu/about/accesspolicy.pdf">University of Notre Dame Archives Access Guidelines </a>and is subject to review under the supervision of the Head of the University Archives.'  # noqa: #501
+        self.assertEqual(actual_results, expected_results)
 
     def fix_file_created_date(self, standard_json: dict, file_created_date: str) -> dict:
         if "fileCreatedDate" in standard_json:


### PR DESCRIPTION
Fixed these truncated terms from ArchivesSpace:
Conditions Governing Access
Conditions Governing Use

To do this, I modified get_xml_node_value to conditionally use ElementTree.tostring if and only if an element has an extref tag and no other child tags.  Otherwise, it will continue to use item.text.