### PR TITLE
skip processing files missing image or media id

### DIFF
--- a/object_files_api/files_api.py
+++ b/object_files_api/files_api.py
@@ -109,6 +109,8 @@ class FilesApi():
             my_json = dict(file_info)
             my_json['sequence'] = i
             my_json['id'] = my_json.get('key', '')
+            if 'mediaGroupId' not in my_json and 'imageGroupId' not in my_json:
+                continue  # We must have either mediaGroupId or imageGroupId or we can't process this record.
             if 'mediaGroupId' in my_json:  # is_media_file(self.config.get('media-file-extensions', []), my_json.get('id')):
                 my_json = add_media_keys(my_json, self.config.get('media-server-base-url', ''))
             else:


### PR DESCRIPTION
* Don't attempt to save into Dynamo any file records missing both imageGroupId and mediaGroupId.