### PR TITLE
MARBLE-1894 Harvest all <p> tags from archivesspace in text fields.

### DIFF
--- a/archivesspace_export/create_json_from_xml.py
+++ b/archivesspace_export/create_json_from_xml.py
@@ -83,6 +83,8 @@ class createJsonFromXml():
         exclude_pattern = field.get('excludePattern', '')
         format = field.get('format', 'array')
         node = []
+        # If the xpath is a p tag, we want to get ALL of them and then join them together
+        array_to_string = format == "text" and xpath.endswith('/p')
         for xml_item in xml.findall(xpath):
             value_found = ""
             if process_other_nodes > "":
@@ -94,10 +96,12 @@ class createJsonFromXml():
                     if value_found in node:
                         value_found = None
             if not(optional and value_found is None):
-                if format == "text":
+                if format == "text" and not array_to_string:
                     node = value_found  # redefine node as string here if needed
                 else:
                     node.append(value_found)
+        if array_to_string:
+          return "\n\n".join(node)
         return node
 
     def _read_xml_to_json_translation_control_file(self, filename: str) -> dict:

--- a/archivesspace_export/create_json_from_xml.py
+++ b/archivesspace_export/create_json_from_xml.py
@@ -101,7 +101,7 @@ class createJsonFromXml():
                 else:
                     node.append(value_found)
         if array_to_string:
-          return "\n\n".join(node)
+            return "\n\n".join(node)
         return node
 
     def _read_xml_to_json_translation_control_file(self, filename: str) -> dict:

--- a/archivesspace_export/test_create_json_from_xml.py
+++ b/archivesspace_export/test_create_json_from_xml.py
@@ -61,7 +61,7 @@ class Test(unittest.TestCase):
         standard_json = self.fix_file_created_date(standard_json, expected_json["fileCreatedDate"])
         self.assertEqual(len(expected_json.keys()), len(standard_json.keys()))
         for key, value in expected_json.items():
-          self.assertEqual(value, standard_json.get(key))
+            self.assertEqual(value, standard_json.get(key))
 
     def test_2_test_extracting_id(self):
         xml_record = ET.fromstring(self.xml)

--- a/archivesspace_export/test_create_json_from_xml.py
+++ b/archivesspace_export/test_create_json_from_xml.py
@@ -59,7 +59,9 @@ class Test(unittest.TestCase):
         with open(local_folder + 'test/MSNEA8011_EAD.json', 'r') as input_source:
             expected_json = json.load(input_source)
         standard_json = self.fix_file_created_date(standard_json, expected_json["fileCreatedDate"])
-        self.assertEqual(expected_json, standard_json)
+        self.assertEqual(len(expected_json.keys()), len(standard_json.keys()))
+        for key, value in expected_json.items():
+          self.assertEqual(value, standard_json.get(key))
 
     def test_2_test_extracting_id(self):
         xml_record = ET.fromstring(self.xml)


### PR DESCRIPTION
We _are_ fetching all nodes with a given xpath, but the way it works now will overwrite the value so that only the last element at that path actually gets into the result. (Or if the field is an array, in which case it returns an array, of course.)

It's hard to know where to stop with this. We could add a property to the translation control config so that specific fields will fetch all nodes and the existing ones will continue to operate as they have... But this kind of seems like behavior that should be the default. If you ask for a "text" field and the input is multiple elements, you _probably_ want the value from all those elements, but have to somehow join them together.

I decided this works pretty cleanly with `<p>` tags. Changing the paragraphs to newlines will cause the resulting text to render basically the same as the original. (That is, a markdown parser will interpret `\n\n` as an indicator for a new paragraph.) It seemed slightly more dangerous to make this assumption on other fields though, so for that reason, I limited the scope of this change to only apply to xpaths which end in `/p`.

*P.S. The unit test change was not essential, but it makes troubleshooting easier. If the test fails, now you will see the difference between expected and actual result for an individual field, instead of the test failing saying the entire json file didn't match, which isn't particularly helpful for troubleshooting.*