### PR TITLE
Encode some dynamo fields

### DIFF
--- a/scripts/codebuild/install.sh
+++ b/scripts/codebuild/install.sh
@@ -15,6 +15,10 @@ pushd bendo_export
 ./local_install.sh
 popd
 
+pushd clean_up_dynamo
+./local_install.sh
+popd
+
 pushd copy_media_content
 ./local_install.sh
 popd


### PR DESCRIPTION
* Added code to manually base64 encode the following fields:
PortfolioCollection.description -> description64
PortfolioUser.bio -> bio64
PortfolioItem.description -> description64
PortfolioItem.annotation -> annotation64

To manually run, navigate to  clean_up_dynamo folder, and run this command from the command line:
python -c 'from clean_up_FileToProcess_records import *; test()'